### PR TITLE
Pass the MTU config from Zephyr to colcon

### DIFF
--- a/modules/libmicroros/libmicroros.mk
+++ b/modules/libmicroros/libmicroros.mk
@@ -35,6 +35,7 @@ configure_colcon_meta: $(COMPONENT_PATH)/colcon.meta $(COMPONENT_PATH)/micro_ros
 	update_meta_from_zephyr_config "CONFIG_MICROROS_SERVERS" "rmw_microxrcedds" "RMW_UXRCE_MAX_SERVICES"; \
 	update_meta_from_zephyr_config "CONFIG_MICROROS_RMW_HISTORIC" "rmw_microxrcedds" "RMW_UXRCE_MAX_HISTORY"; \
 	update_meta_from_zephyr_config "CONFIG_MICROROS_XRCE_DDS_HISTORIC" "rmw_microxrcedds" "RMW_UXRCE_STREAM_HISTORY"; \
+	update_meta_from_zephyr_config "CONFIG_MICROROS_XRCE_DDS_MTU" "microxrcedds_client" "UCLIENT_CUSTOM_TRANSPORT_MTU"; \
 	update_meta "microxrcedds_client" "UCLIENT_PROFILE_SERIAL=OFF"; \
 	update_meta "microxrcedds_client" "UCLIENT_PROFILE_UDP=OFF"; \
 	update_meta "microxrcedds_client" "UCLIENT_PROFILE_TCP=OFF"; \


### PR DESCRIPTION
# Description

In the Kconfig file, an MTU is defined. However, it is not passed to the Colcon build system, which means the MicroROS client always uses the default MTU, which is 512. This causes the publisher to always fail when sending a message larger than 500 bytes. 

In this PR, one line is added to the makefile, so the `configured_colcon.meta` will have the correct MTU set.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] A 1024 byte message (`uint32[256]`) is published from a `nucleo-f746zg` board to a laptop. The MTU is set to 1036 in the `prj.conf`. It succeeds to get the message on the laptop with `ros2 topic echo`.