### PR TITLE
Ignore test_msgs package

### DIFF
--- a/modules/libmicroros/libmicroros.mk
+++ b/modules/libmicroros/libmicroros.mk
@@ -97,7 +97,8 @@ $(COMPONENT_PATH)/micro_ros_src/src:
     touch src/common_interfaces/actionlib_msgs/COLCON_IGNORE; \
 	touch src/common_interfaces/std_srvs/COLCON_IGNORE; \
 	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
-    touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE;
+    touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
+    touch src/rcl_interfaces/test_msgs/COLCON_IGNORE;
 
 $(COMPONENT_PATH)/micro_ros_src/install: configure_colcon_meta configure_toolchain $(COMPONENT_PATH)/micro_ros_dev/install $(COMPONENT_PATH)/micro_ros_src/src
 	cd $(UROS_DIR); \


### PR DESCRIPTION
Signed-off-by: acuadros95 <acuadros1995@gmail.com>

Generated code for `test_msgs` package does not include the `extern "C"` guards to fix name mangling on C++.
As those messages are used only for testing purposes, we can just leave them out of our build process.

Fixes https://github.com/micro-ROS/micro_ros_zephyr_module/issues/98