### PR TITLE
Adjust default_params initialization for cpp compatibility

### DIFF
--- a/modules/libmicroros/microros_transports/udp/microros_transports.h
+++ b/modules/libmicroros/microros_transports/udp/microros_transports.h
@@ -33,7 +33,7 @@ typedef struct {
 } zephyr_transport_params_t;
 
 #define MICRO_ROS_FRAMING_REQUIRED false
-static zephyr_transport_params_t default_params = {.ip = "192.168.1.100", .port = "8888"};
+static zephyr_transport_params_t default_params = {{0,0,0}, "192.168.1.100", "8888"};
 
 bool zephyr_transport_open(struct uxrCustomTransport * transport);
 bool zephyr_transport_close(struct uxrCustomTransport * transport);


### PR DESCRIPTION
Similar to this: https://github.com/micro-ROS/zephyr_apps/pull/57
