### PR TITLE
Enable std services.

### DIFF
--- a/modules/libmicroros/libmicroros.mk
+++ b/modules/libmicroros/libmicroros.mk
@@ -95,7 +95,6 @@ $(COMPONENT_PATH)/micro_ros_src/src:
     touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE; \
     touch src/rclc/rclc_examples/COLCON_IGNORE; \
     touch src/common_interfaces/actionlib_msgs/COLCON_IGNORE; \
-	touch src/common_interfaces/std_srvs/COLCON_IGNORE; \
 	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
     touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
     touch src/rcl_interfaces/test_msgs/COLCON_IGNORE;


### PR DESCRIPTION
Enable the use of standard services(empty, setbool, trigger) in the base deployment of microros.